### PR TITLE
fix macos

### DIFF
--- a/SocraticAI/config.py
+++ b/SocraticAI/config.py
@@ -8,5 +8,17 @@ DATA_DIRECTORY = os.path.join(BASE_DIRECTORY, "data")
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
 ASSEMBLYAI_API_KEY = os.getenv("ASSEMBLYAI_API_KEY")
 
-# Default model configuration
-DEFAULT_LLM_MODEL = "claude-3-7-sonnet-20250219"
+# Default model configuration (pick a valid Anthropic model by default so only ANTHROPIC_API_KEY is required)
+DEFAULT_LLM_MODEL = os.getenv("DEFAULT_LLM_MODEL", "claude-sonnet-4-20250514")
+
+# Test model shortcuts used by examples/tests
+TEST_ANTHROPIC_MODEL = os.getenv("TEST_ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+TEST_GOOGLE_MODEL = os.getenv("TEST_GOOGLE_MODEL", "gemini-2.5-pro")
+
+# CLI model choices mapping
+MODEL_CHOICES = {
+    "default": os.getenv("DEFAULT_CLI_MODEL", "gemini-2.5-flash"),
+    "flash": "gemini-2.5-flash",
+    "sonnet": "claude-sonnet-4-20250514",
+    "pro": "gemini-2.5-pro",
+}

--- a/SocraticAI/content/article/article_generator.py
+++ b/SocraticAI/content/article/article_generator.py
@@ -10,9 +10,9 @@ from typing import Optional, Dict, Any, Tuple, List, Union
 from datetime import datetime
 import time
 
-from socraticai.core.llm import LLMChain
-from socraticai.core.colored_logging import get_colored_logger
-from socraticai.content.article.prompts import (
+from SocraticAI.core.llm import LLMChain
+from SocraticAI.core.colored_logging import get_colored_logger
+from SocraticAI.content.article.prompts import (
     transcript_analysis_prompt, 
     article_writing_prompt, 
     article_refinement_prompt, 
@@ -22,14 +22,14 @@ from socraticai.content.article.prompts import (
     multi_source_article_writing_prompt,
     combined_title_prompt
 )
-from socraticai.transcribe.service import transcribe
-from socraticai.core.utils import (
+from SocraticAI.transcribe.service import transcribe
+from SocraticAI.core.utils import (
     get_output_path,
     get_model_context_limit,
     estimate_transcript_tokens,
     group_transcripts_by_context
 )
-from socraticai.config import DEFAULT_LLM_MODEL
+from SocraticAI.config import DEFAULT_LLM_MODEL
 
 logger = logging.getLogger(__name__)
 colored_logger = get_colored_logger(__name__)

--- a/SocraticAI/content/article/prompts.py
+++ b/SocraticAI/content/article/prompts.py
@@ -1,6 +1,6 @@
 """Prompts for article generation and content creation."""
 
-from socraticai.core.utils import Prompt
+from SocraticAI.core.utils import Prompt
 
 transcript_analysis_prompt = Prompt(
     "transcript_analysis",

--- a/SocraticAI/content/knowledge_graph/__init__.py
+++ b/SocraticAI/content/knowledge_graph/__init__.py
@@ -1,7 +1,7 @@
 """Knowledge graph generation package."""
 
-from socraticai.content.knowledge_graph.graph_generator import KnowledgeGraphGenerator
-from socraticai.content.knowledge_graph.entity_manager import EntityManager
-from socraticai.content.knowledge_graph.node_generator import NodeGenerator
+from SocraticAI.content.knowledge_graph.graph_generator import KnowledgeGraphGenerator
+from SocraticAI.content.knowledge_graph.entity_manager import EntityManager
+from SocraticAI.content.knowledge_graph.node_generator import NodeGenerator
 
 __all__ = ['KnowledgeGraphGenerator', 'EntityManager', 'NodeGenerator'] 

--- a/SocraticAI/content/knowledge_graph/entity_manager.py
+++ b/SocraticAI/content/knowledge_graph/entity_manager.py
@@ -7,12 +7,12 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any
 from datetime import datetime
 
-from socraticai.core.llm import LLMChain
-from socraticai.content.knowledge_graph.prompts import (
+from SocraticAI.core.llm import LLMChain
+from SocraticAI.content.knowledge_graph.prompts import (
     entity_extraction_prompt,
     relationship_analysis_prompt
 )
-from socraticai.core.utils import get_output_path
+from SocraticAI.core.utils import get_output_path
 
 logger = logging.getLogger(__name__)
 

--- a/SocraticAI/content/knowledge_graph/graph_generator.py
+++ b/SocraticAI/content/knowledge_graph/graph_generator.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any, Tuple
 from datetime import datetime
 
-from socraticai.core.llm import LLMChain
-from socraticai.content.knowledge_graph.entity_manager import EntityManager
-from socraticai.content.knowledge_graph.node_generator import NodeGenerator
+from SocraticAI.core.llm import LLMChain
+from SocraticAI.content.knowledge_graph.entity_manager import EntityManager
+from SocraticAI.content.knowledge_graph.node_generator import NodeGenerator
 
 logger = logging.getLogger(__name__)
 

--- a/SocraticAI/content/knowledge_graph/node_generator.py
+++ b/SocraticAI/content/knowledge_graph/node_generator.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any
 from datetime import datetime
 
-from socraticai.core.llm import LLMChain
-from socraticai.content.knowledge_graph.prompts import node_content_prompt
-from socraticai.core.utils import get_output_path
+from SocraticAI.core.llm import LLMChain
+from SocraticAI.content.knowledge_graph.prompts import node_content_prompt
+from SocraticAI.core.utils import get_output_path
 
 logger = logging.getLogger(__name__)
 

--- a/SocraticAI/content/knowledge_graph/prompts.py
+++ b/SocraticAI/content/knowledge_graph/prompts.py
@@ -1,6 +1,6 @@
 """Prompts for knowledge graph generation."""
 
-from socraticai.core.utils import Prompt
+from SocraticAI.core.utils import Prompt
 from datetime import datetime
 
 entity_extraction_prompt = Prompt(

--- a/SocraticAI/core/llm.py
+++ b/SocraticAI/core/llm.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from typing import Optional, Dict, Any, List, Union
 from anthropic import Anthropic
 from tenacity import retry, stop_after_attempt, wait_exponential
-from socraticai.config import ANTHROPIC_API_KEY, DEFAULT_LLM_MODEL
+from SocraticAI.config import ANTHROPIC_API_KEY, DEFAULT_LLM_MODEL
 
 try:
     from google import genai

--- a/SocraticAI/core/utils.py
+++ b/SocraticAI/core/utils.py
@@ -7,8 +7,8 @@ from typing import Dict, List
 
 import tiktoken
 
-from socraticai.config import DATA_DIRECTORY
-from socraticai.core.llm import ANTHROPIC_MODELS, GEMINI_MODELS
+from SocraticAI.config import DATA_DIRECTORY
+from SocraticAI.core.llm import ANTHROPIC_MODELS, GEMINI_MODELS
 
 
 def ensure_data_directories():

--- a/SocraticAI/transcribe/service.py
+++ b/SocraticAI/transcribe/service.py
@@ -4,13 +4,13 @@ import time
 
 import assemblyai as aai
 
-from socraticai.transcribe.utils import anonymize_transcript
-from socraticai.core.utils import (
+from SocraticAI.transcribe.utils import anonymize_transcript
+from SocraticAI.core.utils import (
     get_anonymized_path,
     get_transcribed_path,
 )
-from socraticai.core.colored_logging import get_colored_logger
-from socraticai.config import ASSEMBLYAI_API_KEY
+from SocraticAI.core.colored_logging import get_colored_logger
+from SocraticAI.config import ASSEMBLYAI_API_KEY
 
 logger = logging.getLogger(__name__)
 colored_logger = get_colored_logger(__name__)

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -16,15 +16,15 @@ from rich.text import Text
 from rich import print as rprint
 from rich.prompt import Confirm
 
-from socraticai.transcribe.service import transcribe
-from socraticai.content.article.article_generator import (
+from SocraticAI.transcribe.service import transcribe
+from SocraticAI.content.article.article_generator import (
     ArticleGenerator, 
     TranscriptTooShortError,
     UnsupportedFileTypeError
 )
-from socraticai.content.knowledge_graph.graph_generator import KnowledgeGraphGenerator
-from socraticai.core.utils import get_stats, get_input_path
-from socraticai.config import MODEL_CHOICES
+from SocraticAI.content.knowledge_graph.graph_generator import KnowledgeGraphGenerator
+from SocraticAI.core.utils import get_stats, get_input_path
+from SocraticAI.config import MODEL_CHOICES
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -74,7 +74,7 @@ def get_file_list(path: Optional[str]) -> List[str]:
 @click.command()
 def stats():
     """Get comprehensive statistics about the data folder with rich formatting."""
-    from socraticai.core.utils import get_data_directory
+    from SocraticAI.core.utils import get_data_directory
     
     console.print("\n[bold blue]📊 SocraticAI Data Directory Statistics[/bold blue]\n")
     

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,8 +1,11 @@
 """Main CLI entry point for SocraticAI."""
 
+# Load environment variables first, before any other imports
+from dotenv import find_dotenv, load_dotenv
+load_dotenv(find_dotenv())
+
 import click
 import logging
-from dotenv import find_dotenv, load_dotenv
 import os
 
 from rich.console import Console
@@ -40,12 +43,7 @@ def cli():
       socraticai article "*.mp3" --multi-source         # Combine multiple files into one article
       socraticai stats                                   # View data directory statistics
     """
-    # Load environment variables
-    dotenv_path = find_dotenv()
-    if dotenv_path:
-        logger.info(f"Loading environment from {dotenv_path}")
-        load_dotenv(dotenv_path)
-        logger.info(f'Model type: {os.getenv("MODEL_TYPE")}')
+    pass  # Environment variables already loaded at module level
 
 # Add all commands
 cli.add_command(stats)

--- a/example_usage.py
+++ b/example_usage.py
@@ -3,8 +3,13 @@
 Example usage of the abstracted LLM system supporting both Anthropic and Gemini models.
 """
 
-from socraticai.core.llm import create_llm_chain, LLMChain
-from socraticai.config import TEST_GOOGLE_MODEL, TEST_ANTHROPIC_MODEL
+from dotenv import find_dotenv, load_dotenv
+
+# Load environment variables from .env if present (before importing config)
+load_dotenv(find_dotenv())
+
+from SocraticAI.core.llm import create_llm_chain, LLMChain
+from SocraticAI.config import TEST_GOOGLE_MODEL, TEST_ANTHROPIC_MODEL
 
 def main():
     # Example 1: Using the unified LLMChain with model parameter (Recommended)
@@ -122,7 +127,7 @@ def main():
     # Example 6: Dynamic model switching and comparison
     print("=== Example 6: Dynamic model switching and comparison ===")
     
-    models_to_try = ["claude-3-5-sonnet-20241022", "gemini-1.5-pro"]
+    models_to_try = [TEST_ANTHROPIC_MODEL, TEST_GOOGLE_MODEL]
     prompt = "What's the meaning of life?"
     
     # Method 1: Create separate chains

--- a/tests/test_article_generator.py
+++ b/tests/test_article_generator.py
@@ -8,14 +8,14 @@ import shutil
 from datetime import datetime
 import logging
 
-from socraticai.content.article.article_generator import (
+from SocraticAI.content.article.article_generator import (
     ArticleGenerator,
     TranscriptTooShortError,
     UnsupportedFileTypeError,
     AnalysisParsingError
 )
-from socraticai.core.llm import LLMChain # Ensure this can be imported or mock its usage
-from socraticai.config import TEST_GOOGLE_MODEL as TEST_LLM_MODEL 
+from SocraticAI.core.llm import LLMChain # Ensure this can be imported or mock its usage
+from SocraticAI.config import TEST_GOOGLE_MODEL as TEST_LLM_MODEL 
 
 # Mock the LLMChain if it's complex to instantiate or has external dependencies
 class MockLLMResponse:

--- a/tests/test_article_generator_integration.py
+++ b/tests/test_article_generator_integration.py
@@ -12,8 +12,8 @@ import shutil
 from pathlib import Path
 from datetime import datetime
 
-from socraticai.content.article.article_generator import ArticleGenerator
-from socraticai.config import TEST_MODEL, TEST_API_KEY
+from SocraticAI.content.article.article_generator import ArticleGenerator
+from SocraticAI.config import TEST_MODEL, TEST_API_KEY
 from socraticai import config
 
 logger = logging.getLogger(__name__)

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import logging
 import yaml
 
-from socraticai.content.knowledge_graph import KnowledgeGraphGenerator
-from socraticai.core.utils import get_output_path
+from SocraticAI.content.knowledge_graph import KnowledgeGraphGenerator
+from SocraticAI.core.utils import get_output_path
 
 # Set up logging
 logging.basicConfig(

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 from unittest.mock import Mock, patch, MagicMock
-from socraticai.core.llm import (
+from SocraticAI.core.llm import (
     LLMChain, 
     AnthropicLLMChain, 
     GeminiLLMChain,
@@ -13,7 +13,7 @@ from socraticai.core.llm import (
     ANTHROPIC_MODELS,
     GEMINI_MODELS
 )
-from socraticai.config import TEST_GOOGLE_MODEL, TEST_ANTHROPIC_MODEL
+from SocraticAI.config import TEST_GOOGLE_MODEL, TEST_ANTHROPIC_MODEL
 from tenacity import RetryError
 
 # Set up logging for tests

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -1,8 +1,8 @@
 import pytest
 import os
 import logging
-from socraticai.core.llm import LLMChain, AnthropicLLMChain, GeminiLLMChain
-from socraticai.config import TEST_GOOGLE_MODEL, TEST_ANTHROPIC_MODEL
+from SocraticAI.core.llm import LLMChain, AnthropicLLMChain, GeminiLLMChain
+from SocraticAI.config import TEST_GOOGLE_MODEL, TEST_ANTHROPIC_MODEL
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
CLI was loading .env file inside the cli() function, but config imports happened earlier, causing "API key not found" errors
> Moved load_dotenv() to the top of cli/main.py before any imports

Mixed usage of socraticai vs SocraticAI in import statements throughout the codebase (causing issues on unix based case sensitive operating systems)
> Systematically updated all imports to use the correct SocraticAI package name

