### PR TITLE
Fix ImportError by adding MODEL_CHOICES to config

### DIFF
--- a/SocraticAI/config.py
+++ b/SocraticAI/config.py
@@ -10,3 +10,11 @@ ASSEMBLYAI_API_KEY = os.getenv("ASSEMBLYAI_API_KEY")
 
 # Default model configuration
 DEFAULT_LLM_MODEL = "claude-3-7-sonnet-20250219"
+
+# Model choices for CLI
+MODEL_CHOICES = {
+    "default": "gemini-2.5-flash",
+    "flash": "gemini-2.5-flash",
+    "sonnet": "claude-sonnet-4-20250514",
+    "pro": "gemini-2.5-pro"
+}


### PR DESCRIPTION
## Summary
Added `MODEL_CHOICES` dictionary to `config.py` to fix ImportError when running the article generation command.

## Problem
The CLI commands module (`cli/commands.py`) was trying to import `MODEL_CHOICES` from `socraticai.config`, but this constant was not defined, causing an ImportError:
```
ImportError: cannot import name 'MODEL_CHOICES' from 'socraticai.config'
```

## Solution
Added the `MODEL_CHOICES` dictionary to `socraticai/config.py` with mappings for:
- `default`: gemini-2.5-flash
- `flash`: gemini-2.5-flash
- `sonnet`: claude-sonnet-4-20250514
- `pro`: gemini-2.5-pro

## Test plan
- [x] Verified the import error is resolved
- [x] Tested article generation command runs successfully: `poetry run socraticai article "Richard-Sorge-Straße 24 24.m4a"`
- [x] Command now properly starts processing without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)